### PR TITLE
Tweaks to release process for cross-building

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Internationalisation classes for use by the various supporter sites such as [mem
 Releasing to local repo
 ==================
 
-Run `sbt publishLocal`.
+Run `sbt +publishLocal`.
 
 
 Releasing to maven

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Internationalisation classes for use by the various supporter sites such as [mem
 Releasing to local repo
 ==================
 
-Run `sbt +publishLocal`.
+Run `sbt publishLocal`.
 
 
 Releasing to maven
@@ -13,4 +13,4 @@ Releasing to maven
 We use sbt to release to Maven. Please check notes here to ensure you are set up to release to Maven:
 https://docs.google.com/document/d/1M_MiE8qntdDn97QIRnIUci5wdVQ8_defCqpeAwoKY8g/edit#heading=h.r815791vmxv5
 
-Then run `sbt +release`.
+Then run `sbt release`.

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.gu"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.12.2")
+crossScalaVersions := Seq("2.11.8", "2.12.2")
 
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/support-internationalisation"),
@@ -17,6 +17,7 @@ description := "Scala library to provide internationalisation classes to Guardia
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
+releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -25,10 +26,10 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _)),
+  ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
   pushChanges
 )
 


### PR DESCRIPTION
I only seem to have released version 0.4 for 2.12. 

https://repo.maven.apache.org/maven2/com/gu/support-internationalisation_2.12/
https://repo.maven.apache.org/maven2/com/gu/support-internationalisation_2.11/

Looking at the sbt-release README (https://github.com/sbt/sbt-release/blob/master/README.md), I spotted the following line:
"If the crossScalaVersions setting is set, then only these scala versions will be used. Make sure to include the regular/default scalaVersion in the crossScalaVersion setting as well."

I've also tweaked our build.sbt slightly based on another library which I've successfully cross-built before (https://github.com/guardian/tip/blob/master/build.sbt). I think this allows us to drop the '+' and cross-build on 'sbt release' by default, but perhaps @mario-galic can confirm?

cc @davidfurey - let me know if I've missed something here!