### PR TITLE
Country matching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.11.8", "2.12.2")
 
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/support-internationalisation"),
   "scm:git:git@github.com:guardian/support-internationalisation.git"

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -1,6 +1,8 @@
 
 package com.gu.i18n
 
+import java.util.Locale
+
 case class CountryGroup(name: String,
                         id: String,
                         defaultCountry: Option[Country],
@@ -292,7 +294,16 @@ object CountryGroup {
 
   val countries: List[Country] = allGroups.flatMap(_.countries).sortBy(_.name)
 
-  def countryByCode(str: String): Option[Country] = countries.find { _.alpha2 == str }
+  val countriesByISO2: Map[String, Country] = countries.map{c => c.alpha2 -> c}.toMap
+
+  val countriesByISO3 = countries.map { country =>
+    val locale = new Locale("", country.alpha2)
+    locale.getISO3Country.toUpperCase -> country
+  }.toMap
+
+  def countryByCode(str: String): Option[Country] = countries.find { _.alpha2 == str } orElse countriesByISO3.get(str)
+
+
 
   def countryByName(str: String): Option[Country] = countries.find { _.name.equalsIgnoreCase(str) }
 
@@ -322,7 +333,6 @@ object CountryGroup {
       case _ if name endsWith "of ireland" => Some(Country.Ireland)
       case _ if asCode == "GB" => Some(Country.UK)
       case _ if name == "great britain" => Some(Country.UK)
-      case _ if asCode == "USA" => Some(Country.US)
       case _ if name == "viet nam" => countryByCode("VN")
       case _ if name startsWith "the " => countryByName(name.replaceFirst("the ", ""))
       case _ if name == "russian federation" => countryByCode("RU")

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -309,18 +309,13 @@ object CountryGroup {
   // in Identity but then trying to find it by code. It's not clear anymore which we have in our systems; probably both
   def countryByNameOrCode(str: String): Option[Country] = countries.find { _.name == str } orElse countryByCode(str)
 
-  def byCountryCode(c: String): Option[CountryGroup] = {
-    val country = countryByCode(c)
-    allGroups.find(_.countries.contains(country))
-  }
+  def byCountryCode(c: String): Option[CountryGroup] = allGroups.find(_.countries.exists(_.alpha2 == c))
 
   def byFastlyCountryCode(c: String): Option[CountryGroup] =
     byCountryCode(c) orElse Some(CountryGroup.Europe).filter(_ => c == "EU")
 
-  def byCountryNameOrCode(str: String): Option[CountryGroup] = {
-    val country = countryByNameOrCode(str)
-    allGroups.find(_.countries.contains(country))
-  }
+  def byCountryNameOrCode(str: String): Option[CountryGroup] =
+    allGroups.find(_.countries.exists(_.name == str)) orElse byCountryCode(str)
 
   def byId(id: String): Option[CountryGroup] = allGroups.find(_.id == id)
 

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -317,8 +317,10 @@ object CountryGroup {
   def byFastlyCountryCode(c: String): Option[CountryGroup] =
     byCountryCode(c) orElse Some(CountryGroup.Europe).filter(_ => c == "EU")
 
-  def byCountryNameOrCode(str: String): Option[CountryGroup] =
-    allGroups.find(_.countries.exists(_.name == str)) orElse byCountryCode(str)
+  def byCountryNameOrCode(str: String): Option[CountryGroup] = {
+    val country = countryByNameOrCode(str)
+    allGroups.find(_.countries.contains(country))
+  }
 
   def byId(id: String): Option[CountryGroup] = allGroups.find(_.id == id)
 

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -294,7 +294,7 @@ object CountryGroup {
 
   def countryByCode(str: String): Option[Country] = countries.find { _.alpha2 == str }
 
-  def countryByName(str: String): Option[Country] = countries.find { _.name.toLowerCase == str.toLowerCase }
+  def countryByName(str: String): Option[Country] = countries.find { _.name.equalsIgnoreCase(str) }
 
   // This is because there was an inconsistency in the code where we were writing a country name
   // in Identity but then trying to find it by code. It's not clear anymore which we have in our systems; probably both
@@ -319,10 +319,13 @@ object CountryGroup {
     val name = clean.toLowerCase
 
     countryByName(name) orElse countryByCode(asCode) orElse (name match {
-      case _ if name endsWith "ireland" => Some(Country.Ireland)
+      case _ if name endsWith "of ireland" => Some(Country.Ireland)
+      case _ if asCode == "GB" => Some(Country.UK)
+      case _ if name == "great britain" => Some(Country.UK)
       case _ if asCode == "USA" => Some(Country.US)
-      case _ if name startsWith "the" => countryByName(name.replaceFirst("the", "").trim)
-      case _ if name == "russian federation" => countryByName("Russia")
+      case _ if name == "viet nam" => countryByCode("VN")
+      case _ if name startsWith "the " => countryByName(name.replaceFirst("the ", ""))
+      case _ if name == "russian federation" => countryByCode("RU")
       case _ => None
     })
   }

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -301,9 +301,7 @@ object CountryGroup {
     locale.getISO3Country.toUpperCase -> country
   }.toMap
 
-  def countryByCode(str: String): Option[Country] = countries.find { _.alpha2 == str } orElse countriesByISO3.get(str)
-
-
+  def countryByCode(str: String): Option[Country] = countriesByISO2.get(str) orElse countriesByISO3.get(str)
 
   def countryByName(str: String): Option[Country] = countries.find { _.name.equalsIgnoreCase(str) }
 
@@ -311,7 +309,10 @@ object CountryGroup {
   // in Identity but then trying to find it by code. It's not clear anymore which we have in our systems; probably both
   def countryByNameOrCode(str: String): Option[Country] = countries.find { _.name == str } orElse countryByCode(str)
 
-  def byCountryCode(c: String): Option[CountryGroup] = allGroups.find(_.countries.exists(_.alpha2 == c))
+  def byCountryCode(c: String): Option[CountryGroup] = {
+    val country = countryByCode(c)
+    allGroups.find(_.countries.contains(country))
+  }
 
   def byFastlyCountryCode(c: String): Option[CountryGroup] =
     byCountryCode(c) orElse Some(CountryGroup.Europe).filter(_ => c == "EU")

--- a/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -44,6 +44,7 @@ class CountryGroupTest extends FlatSpec {
   }
   it should "identify countries from common alternatives" in {
     val tests = List(
+      "FRANCE" -> CountryGroup.countryByCode("FR").get,
       "usa" -> Country.US,
       "republic of ireland" -> Country.Ireland,
       "rep. of ireland" -> Country.Ireland,

--- a/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -1,0 +1,56 @@
+package com.gu.i18n
+
+
+import Currency._
+import org.scalatest.FlatSpec
+
+class CountryGroupTest extends FlatSpec {
+
+
+  "A CountryGroup" should "be found by id" in {
+    assert(CountryGroup.byId("ie") === None)
+    assert(CountryGroup.byId("eu") === Some(CountryGroup.Europe))
+    assert(CountryGroup.byId("int") === Some(CountryGroup.RestOfTheWorld))
+  }
+
+  it should "be found by its countries names and codes" in {
+    assert(CountryGroup.byCountryNameOrCode(Country.Australia.alpha2) === Some(CountryGroup.Australia))
+    assert(CountryGroup.byCountryNameOrCode(Country.Australia.name) === Some(CountryGroup.Australia))
+    assert(CountryGroup.byCountryNameOrCode(Country.US.alpha2) === Some(CountryGroup.US))
+    assert(CountryGroup.byCountryNameOrCode(Country.US.name) === Some(CountryGroup.US))
+    assert(CountryGroup.byCountryNameOrCode("Italy") === Some(CountryGroup.Europe))
+    assert(CountryGroup.byCountryNameOrCode("IT") === Some(CountryGroup.Europe))
+    assert(CountryGroup.byCountryNameOrCode("AF") === Some(CountryGroup.RestOfTheWorld))
+    assert(CountryGroup.byCountryNameOrCode("Afghanistan") === Some(CountryGroup.RestOfTheWorld))
+    assert(CountryGroup.byCountryNameOrCode("IE") === Some(CountryGroup.Europe))
+  }
+
+  it should "correctly identify its currencies" in {
+    assert(CountryGroup.availableCurrency(Set.empty)(Country.UK) === None)
+    assert(CountryGroup.availableCurrency(Set(GBP, AUD))(Country.US) === None)
+    assert(CountryGroup.availableCurrency(Set(GBP, AUD))(Country.UK) === Some(GBP))
+    assert(CountryGroup.availableCurrency(Set(GBP, AUD))(Country.Australia) === Some(AUD))
+  }
+
+  it should "identify countries correctly" in {
+    CountryGroup.countries.map { c =>
+      assert(
+        CountryGroup.byOptimisticCountryNameOrCode(c.name) === Some(c)
+      )
+      assert(
+        CountryGroup.byOptimisticCountryNameOrCode(c.alpha2) === Some(c)
+      )
+    }
+  }
+  it should "identify countries from common alternatives" in {
+    val tests = List(
+      "usa" -> Country.US,
+      "republic of ireland" -> Country.Ireland,
+      "the netherlands" -> CountryGroup.countryByName("Netherlands").get,
+      "the czech republic" -> CountryGroup.countryByName("Czech Republic").get
+    )
+    tests.map { case (name: String, country: Country) => assert(CountryGroup.byOptimisticCountryNameOrCode(name) === Some(country)) }
+  }
+
+
+}

--- a/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -46,8 +46,10 @@ class CountryGroupTest extends FlatSpec {
     val tests = List(
       "usa" -> Country.US,
       "republic of ireland" -> Country.Ireland,
-      "the netherlands" -> CountryGroup.countryByName("Netherlands").get,
-      "the czech republic" -> CountryGroup.countryByName("Czech Republic").get
+      "great britain" -> Country.UK,
+      "the netherlands" -> CountryGroup.countryByCode("NL").get,
+      "the czech republic" -> CountryGroup.countryByCode("CZ").get,
+      "viet nam" -> CountryGroup.countryByCode("VN").get
     )
     tests.map { case (name: String, country: Country) => assert(CountryGroup.byOptimisticCountryNameOrCode(name) === Some(country)) }
   }

--- a/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -46,6 +46,7 @@ class CountryGroupTest extends FlatSpec {
     val tests = List(
       "usa" -> Country.US,
       "republic of ireland" -> Country.Ireland,
+      "rep. of ireland" -> Country.Ireland,
       "great britain" -> Country.UK,
       "the netherlands" -> CountryGroup.countryByCode("NL").get,
       "the czech republic" -> CountryGroup.countryByCode("CZ").get,


### PR DESCRIPTION
Some logic which makes country matching somewhat looser so we don't have to discard slightly off countries when stored in identity. Changes existing behaviour in `countryByName` so might pull that change into its own function. 