### PR TITLE
Adding 3 new optimistic mappings

### DIFF
--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -326,10 +326,12 @@ object CountryGroup {
     byCountryCode(country.alpha2).map(_.currency).filter(currencies)
 
   def byOptimisticCountryNameOrCode(str: String): Option[Country] = {
-    val clean = str.replace(".", "")
+    val clean = str.replace(".", "").trim
     val name = clean.toLowerCase
+    val nameAmpersand = name.replace(" and ", " & ")
 
-    countryByName(name) orElse countryByCode(clean) orElse (name match {
+    countryByCode(clean) orElse countryByName(name) orElse countryByName(nameAmpersand) orElse (name match {
+      case _ if name equals "united states of america" => Some(Country.US)
       case _ if name endsWith "of ireland" => Some(Country.Ireland)
       case _ if clean == "GB" => Some(Country.UK)
       case _ if name == "great britain" => Some(Country.UK)

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -326,6 +326,7 @@ object CountryGroup {
     byCountryCode(country.alpha2).map(_.currency).filter(currencies)
 
   def byOptimisticCountryNameOrCode(str: String): Option[Country] = {
+    if (str == null) return None
     val clean = str.replace(".", "").trim
     val name = clean.toLowerCase
     val nameAmpersand = name.replace(" and ", " & ")

--- a/src/main/scala/com/gu/i18n/CountryGroup.scala
+++ b/src/main/scala/com/gu/i18n/CountryGroup.scala
@@ -329,9 +329,10 @@ object CountryGroup {
     if (str == null) return None
     val clean = str.replace(".", "").trim
     val name = clean.toLowerCase
+    val nameAnd = name.replace(" & ", " and ")
     val nameAmpersand = name.replace(" and ", " & ")
 
-    countryByCode(clean) orElse countryByName(name) orElse countryByName(nameAmpersand) orElse (name match {
+    countryByCode(clean) orElse countryByName(name) orElse countryByName(nameAnd) orElse countryByName(nameAmpersand) orElse (name match {
       case _ if name equals "united states of america" => Some(Country.US)
       case _ if name endsWith "of ireland" => Some(Country.Ireland)
       case _ if clean == "GB" => Some(Country.UK)

--- a/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -42,6 +42,11 @@ class CountryGroupTest extends FlatSpec {
       )
     }
   }
+
+  it should "handle null and return None" in {
+    CountryGroup.byOptimisticCountryNameOrCode(null) === None
+  }
+
   it should "identify countries from common alternatives" in {
     val tests = List(
       "FRANCE" -> CountryGroup.countryByCode("FR").get,

--- a/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -51,7 +51,9 @@ class CountryGroupTest extends FlatSpec {
       "great britain" -> Country.UK,
       "the netherlands" -> CountryGroup.countryByCode("NL").get,
       "the czech republic" -> CountryGroup.countryByCode("CZ").get,
-      "viet nam" -> CountryGroup.countryByCode("VN").get
+      "viet nam" -> CountryGroup.countryByCode("VN").get,
+      "united states of america" -> Country.US,
+      "trinidad and tobago" -> CountryGroup.countryByCode("TT").get
     )
     tests.map { case (name: String, country: Country) => assert(CountryGroup.byOptimisticCountryNameOrCode(name) === Some(country)) }
   }


### PR DESCRIPTION
Adding 3 new optimistic mappings:
- united states of america
- " & " to " and "
- " and " to " & "

And support null passed in to `byOptimisticCountryNameOrCode`
cc @AWare @pvighi 